### PR TITLE
Update HELICS-src GitHub url in build_tarballs.jl

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 sources = [
-    "https://github.com/gmlc-tdc/helics-src/archive/v2.0.0-rc1.tar.gz" => "47524ea2558961a6b924a1f972b2d063ca43daa092d91b3b8865ae06f5b33961",
+    "https://github.com/gmlc-tdc/helics/archive/v2.0.0-rc1.tar.gz" => "47524ea2558961a6b924a1f972b2d063ca43daa092d91b3b8865ae06f5b33961",
     "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2" =>
     "7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7",
 ]


### PR DESCRIPTION
Update the HELICS-src GitHub url after HELICS-src to HELICS repository rename on June 19, 2019.